### PR TITLE
Fix for PHP8 exceptions

### DIFF
--- a/HideSubmit.php
+++ b/HideSubmit.php
@@ -70,6 +70,7 @@ public function redcap_every_page_before_render($project_id) {
 
         foreach ($hideSubmitTags as $tag){
             $fields = $this->getTags($tag);
+            if (empty($fields)) continue;
             $fields = array_keys($fields[$tag]);
             $hideSubmitFields = array_merge((array)$hideSubmitFields,(array)$fields); 
         };
@@ -83,6 +84,7 @@ public function redcap_every_page_before_render($project_id) {
 
         foreach ($hideRepeatTags as $tag){
             $fields = $this->getTags($tag);
+            if (empty($fields)) continue;
             $fields = array_keys($fields[$tag]);
             $hideRepeatFields = array_merge((array)$hideRepeatFields,(array)$fields); 
         };
@@ -170,6 +172,7 @@ public function redcap_every_page_before_render($project_id) {
 
         foreach ($hideSubmitTags as $tag){
             $fields = $this->getTags($tag);
+            if (empty($fields)) continue;
             $fields = array_keys($fields[$tag]);
             $hideSubmitFields = array_merge((array)$hideSubmitFields,(array)$fields); 
         };
@@ -183,6 +186,7 @@ public function redcap_every_page_before_render($project_id) {
 
         foreach ($hideRepeatTags as $tag){
             $fields = $this->getTags($tag);
+            if (empty($fields)) continue;
             $fields = array_keys($fields[$tag]);
             $hideRepeatFields = array_merge((array)$hideRepeatFields,(array)$fields); 
         };


### PR DESCRIPTION
PHP8 generates exception messages when using array_keys(null):

The 'hide_submit' module threw the following exception when calling the hook method 'redcap_survey_page_top':

TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in C:\xampp\htdocs\redcapdev\modules_mcri_dev\hide_submit_v0.0.0\HideSubmit.php:73
Stack trace:
#0 C:\xampp\htdocs\redcapdev\modules_mcri_dev\hide_submit_v0.0.0\HideSubmit.php(73): array_keys(NULL)
#1 C:\xampp\htdocs\redcapdev\redcap_v12.2.8\ExternalModules\classes\ExternalModules.php(2889): INTERSECT\HideSubmit\HideSubmit->redcap_survey_page_top('33', '1', 'entry', '87', NULL, 'DLLqL9hR3uVfIVc...', '29', 1)
#2 C:\xampp\htdocs\redcapdev\redcap_v12.2.8\ExternalModules\classes\ExternalModules.php(3017): ExternalModules\ExternalModules::startHook('hide_submit', 'v0.0.0', Array)
#3 C:\xampp\htdocs\redcapdev\redcap_v12.2.8\ExternalModules\classes\ExternalModules.php(3050): ExternalModules\ExternalModules::ExternalModules\{closure}('hide_submit', 'v0.0.0')
#4 C:\xampp\htdocs\redcapdev\redcap_v12.2.8\Classes\Hooks.php(42): ExternalModules\ExternalModules::callHook('survey_page_top', Array)
#5 C:\xampp\htdocs\redcapdev\redcap_v12.2.8\Surveys\index.php(2433): Hooks::call('redcap_survey_p...', Array)
#6 C:\xampp\htdocs\redcapdev\surveys\index.php(9): include('C:\\xampp\\htdocs...')
#7 {main}