### PR TITLE
Initialize parsed_tags as an empty array if needed

### DIFF
--- a/classes/ActionTagHelper.php
+++ b/classes/ActionTagHelper.php
@@ -55,6 +55,11 @@ class ActionTagHelper
             $field_annotation = $field['field_annotation'];
             $parsed_tags = self::parseActionTags($field_annotation);
             // \Plugin::log($tags, "DEBUG", "TAGS for $field_name");
+
+            if (!is_array($parsed_tags)) {
+                $parsed_tags = [];
+            }
+            
             foreach ($parsed_tags as $tag) {
                 // All action-tags should be parsed as uppercase
                 $action_tag = strtoupper($tag['actiontag']);


### PR DESCRIPTION
Ensure parsed_tags is an array if not already.

Address bug:  Error message: Warning - foreach() argument must be of type array|object, bool given, File: modules/hide_submit_v3.1.0/classes/ActionTagHelper.php, Line: 58